### PR TITLE
Tdpreece/linux compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@ nosetests.xml
 
 *.received.*
 
+*.swp
+.ropeproject/*
 .idea/*

--- a/approvaltests/Namer.py
+++ b/approvaltests/Namer.py
@@ -27,4 +27,4 @@ class Namer(object):
         return self.Directory
 
     def get_basename(self):
-        return self.Directory + "\\" + self.ClassName + "." + self.MethodName
+        return os.path.join(self.Directory, self.ClassName + "." + self.MethodName)

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -13,7 +13,7 @@ class TextDiffReporter(Reporter):
     @classmethod
     def get_command(cls, approved_path, received_path):
         diff_tool = os.environ[cls.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME]
-        return [diff_tool, approved_path, received_path]
+        return [diff_tool, received_path, approved_path]
 
     def report(self, approved_path, received_path):
         if not os.path.isfile(approved_path):

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -12,5 +12,6 @@ class TextDiffReporter(Reporter):
         return [diff_tool, approved_path, received_path]
 
     def report(self, approved_path, received_path):
+        os.mknod(approved_path)
         command_array = self.get_command(approved_path, received_path)
         subprocess.call(command_array)

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -12,6 +12,7 @@ class TextDiffReporter(Reporter):
         return [diff_tool, approved_path, received_path]
 
     def report(self, approved_path, received_path):
-        os.mknod(approved_path)
+        if not os.path.isfile(approved_path):
+            os.mknod(approved_path)
         command_array = self.get_command(approved_path, received_path)
         subprocess.call(command_array)

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -17,8 +17,7 @@ class TextDiffReporter(Reporter):
 
     def report(self, approved_path, received_path):
         if not os.path.isfile(approved_path):
-            with open(approved_path, 'w') as approved_file:
-                pass
+            open(approved_path, 'w').close()
         command_array = self.get_command(approved_path, received_path)
         self.run_command(command_array)
 

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -6,6 +6,10 @@ from approvaltests.Reporter import Reporter
 class TextDiffReporter(Reporter):
     DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME = 'APPROVALS_TEXT_DIFF_TOOL'
 
+    @staticmethod
+    def run_command(command_array):
+        subprocess.call(command_array)
+
     @classmethod
     def get_command(cls, approved_path, received_path):
         diff_tool = os.environ[cls.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME]
@@ -13,6 +17,8 @@ class TextDiffReporter(Reporter):
 
     def report(self, approved_path, received_path):
         if not os.path.isfile(approved_path):
-            os.mknod(approved_path)
+            with open(approved_path, 'w') as approved_file:
+                pass
         command_array = self.get_command(approved_path, received_path)
-        subprocess.call(command_array)
+        self.run_command(command_array)
+

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -10,6 +10,10 @@ class TextDiffReporter(Reporter):
     def run_command(command_array):
         subprocess.call(command_array)
 
+    @staticmethod
+    def create_empty_file(file_path):
+        open(file_path, 'w').close()
+
     @classmethod
     def get_command(cls, approved_path, received_path):
         diff_tool = os.environ[cls.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME]
@@ -17,7 +21,7 @@ class TextDiffReporter(Reporter):
 
     def report(self, approved_path, received_path):
         if not os.path.isfile(approved_path):
-            open(approved_path, 'w').close()
+            self.create_empty_file(approved_path)
         command_array = self.get_command(approved_path, received_path)
         self.run_command(command_array)
 

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+from approvaltests.Reporter import Reporter
+
+
+class TextDiffReporter(Reporter):
+    DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME = 'APPROVALS_TEXT_DIFF_TOOL'
+
+    @classmethod
+    def get_command(cls, approved_path, received_path):
+        diff_tool = os.environ[cls.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME]
+        return [diff_tool, approved_path, received_path]
+
+    def report(self, approved_path, received_path):
+        command_array = self.get_command(approved_path, received_path)
+        subprocess.call(command_array)

--- a/examples/text_diff_reporter_example.py
+++ b/examples/text_diff_reporter_example.py
@@ -1,0 +1,16 @@
+from approvaltests import Approvals
+from approvaltests.TextDiffReporter import TextDiffReporter
+import os
+import unittest
+
+
+class Test(unittest.TestCase):
+    def test(self):
+        # This environment variable should be set somewhere outside of the test
+        # but is here to make the example clearer.
+        os.environ["APPROVALS_TEXT_DIFF_TOOL"] = "meld"
+        reporter = TextDiffReporter()
+        Approvals.verify("x", reporter)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/NamerTests.py
+++ b/src/NamerTests.py
@@ -18,7 +18,7 @@ class NamerTests(unittest.TestCase):
 
     def test_basename(self):
         n = Namer()
-        self.assertTrue(n.get_basename().endswith("\\NamerTests.test_basename"), n.get_basename())
+        self.assertTrue(n.get_basename().endswith("NamerTests.test_basename"), n.get_basename())
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -14,7 +14,7 @@ class TextDiffReportertests(unittest.TestCase):
         if os.path.exists(self.tmp_dir):
             shutil.rmtree(self.tmp_dir)
         os.mkdir(self.tmp_dir)
-        self.receieved_file_path = 'b.txt'
+        self.received_file_path = 'b.txt'
         self.approved_file_path = os.path.join(
             self.tmp_dir,
             'approved_file.txt'
@@ -27,14 +27,14 @@ class TextDiffReportertests(unittest.TestCase):
 
     def test_constructs_valid_diff_command(self):
         reporter = TextDiffReporter()
-        command = reporter.get_command(self.approved_file_path, self.receieved_file_path)
-        self.assertEqual(command, [self.diff_tool, self.approved_file_path, self.receieved_file_path])
+        command = reporter.get_command(self.approved_file_path, self.received_file_path)
+        self.assertEqual(command, [self.diff_tool, self.approved_file_path, self.received_file_path])
 
     def test_empty_approved_file_created_when_one_does_not_exist(self):
         self.assertFileDoesNotExist(self.approved_file_path)
 
         reporter = TextDiffReporter()
-        reporter.report(self.approved_file_path, self.receieved_file_path)
+        reporter.report(self.approved_file_path, self.received_file_path)
 
         self.assertFileIsEmpty(self.approved_file_path)
 
@@ -43,7 +43,7 @@ class TextDiffReportertests(unittest.TestCase):
         with open(self.approved_file_path, 'w') as approved_file:
             approved_file.write(approved_contents)
         reporter = TextDiffReporter()
-        reporter.report(self.approved_file_path, self.receieved_file_path)
+        reporter.report(self.approved_file_path, self.received_file_path)
 
         with open(self.approved_file_path, 'r') as approved_file:
             actual_contents = approved_file.read()

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -14,7 +14,10 @@ class TextDiffReportertests(unittest.TestCase):
         if os.path.exists(self.tmp_dir):
             shutil.rmtree(self.tmp_dir)
         os.mkdir(self.tmp_dir)
-        self.received_file_path = 'b.txt'
+        self.received_file_path = os.path.join(
+            self.tmp_dir,
+            'received_file.txt'
+        )
         self.approved_file_path = os.path.join(
             self.tmp_dir,
             'approved_file.txt'

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -5,6 +5,10 @@ from approvaltests.TextDiffReporter import TextDiffReporter
 
 
 class TextDiffReportertests(unittest.TestCase):
+    @staticmethod
+    def set_environment_variable(name, value):
+        os.environ[name] = value
+
     @property
     def tmp_dir(self):
         test_dir = os.path.dirname(os.path.realpath(__file__))
@@ -23,7 +27,10 @@ class TextDiffReportertests(unittest.TestCase):
             'approved_file.txt'
         )
         self.diff_tool = 'echo'
-        os.environ[TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME] = self.diff_tool
+        self.set_environment_variable(
+            TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME,
+            self.diff_tool
+        )
 
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -57,8 +57,8 @@ class TextDiffReportertests(unittest.TestCase):
         )
         expected_command = [
             self.diff_tool,
-            self.approved_file_path,
-            self.received_file_path
+            self.received_file_path,
+            self.approved_file_path
         ]
         self.assertEqual(command, expected_command)
 

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -43,8 +43,6 @@ class TextDiffReportertests(unittest.TestCase):
             TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME,
             self.diff_tool
         )
-        open(self.received_file_path, 'w').close()
-
 
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -26,13 +26,9 @@ class TextDiffReportertests(unittest.TestCase):
         shutil.rmtree(self.tmp_dir)
 
     def test_constructs_valid_diff_command(self):
-        diff_tool = 'meld'
-        approved_path = 'a.txt'
-        received_path = 'b.txt'
-        os.environ[TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME] = diff_tool
         reporter = TextDiffReporter()
-        command = reporter.get_command(approved_path, received_path)
-        self.assertEqual(command, [diff_tool, approved_path, received_path])
+        command = reporter.get_command(self.approved_file_path, self.receieved_file_path)
+        self.assertEqual(command, [self.diff_tool, self.approved_file_path, self.receieved_file_path])
 
     def test_empty_approved_file_created_when_one_does_not_exist(self):
         self.assertFileDoesNotExist(self.approved_file_path)

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -1,8 +1,19 @@
 import os
+import shutil
 import unittest
 from approvaltests.TextDiffReporter import TextDiffReporter
 
+
 class TextDiffReportertests(unittest.TestCase):
+    @property
+    def tmp_dir(self):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        return os.path.join(test_dir, 'tmp')
+
+    def setUp(self):
+        shutil.rmtree(self.tmp_dir)
+        os.mkdir(self.tmp_dir)
+
     def test_constructs_valid_diff_command(self):
         diff_tool = 'meld'
         approved_path = 'a.txt'
@@ -11,6 +22,31 @@ class TextDiffReportertests(unittest.TestCase):
         reporter = TextDiffReporter()
         command = reporter.get_command(approved_path, received_path)
         self.assertEqual(command, [diff_tool, approved_path, received_path])
+
+    def test_empty_approved_file_created_when_one_does_not_exist(self):
+        diff_tool = 'echo'
+        receieved_file_path = 'b.txt'
+        approved_file_path = os.path.join(self.tmp_dir, 'approved_file.txt')
+        os.environ[TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME] = diff_tool
+        self.assertFileDoesNotExist(approved_file_path)
+
+        reporter = TextDiffReporter()
+        reporter.report(approved_file_path, receieved_file_path)
+
+        self.assertFileIsEmpty(approved_file_path)
+
+    def assertFileDoesNotExist(self, file_path):
+        file_exists = os.path.isfile(file_path)
+        if file_exists:
+            msg = "File {} exists when it shouldn't".format(file_path)
+            self.fail(msg)
+
+    def assertFileIsEmpty(self, file_path):
+        file_size = os.stat(file_path).st_size
+        if file_size != 0:
+            msg = "File is not empty: {}" % file_path
+            self.fail(msg)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -43,17 +43,13 @@ class TextDiffReportertests(unittest.TestCase):
         self.assertFileIsEmpty(self.approved_file_path)
 
     def test_approved_file_not_changed_when_one_exists_already(self):
-        diff_tool = 'echo'
-        receieved_file_path = 'b.txt'
-        approved_file_path = os.path.join(self.tmp_dir, 'approved_file.txt')
-        os.environ[TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME] = diff_tool
         approved_contents = "Approved"
-        with open(approved_file_path, 'w') as approved_file:
+        with open(self.approved_file_path, 'w') as approved_file:
             approved_file.write(approved_contents)
         reporter = TextDiffReporter()
-        reporter.report(approved_file_path, receieved_file_path)
+        reporter.report(self.approved_file_path, self.receieved_file_path)
 
-        with open(approved_file_path, 'r') as approved_file:
+        with open(self.approved_file_path, 'r') as approved_file:
             actual_contents = approved_file.read()
         self.assertEqual(actual_contents, approved_contents)
 

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -1,0 +1,16 @@
+import os
+import unittest
+from approvaltests.TextDiffReporter import TextDiffReporter
+
+class TextDiffReportertests(unittest.TestCase):
+    def test_constructs_valid_diff_command(self):
+        diff_tool = 'meld'
+        approved_path = 'a.txt'
+        received_path = 'b.txt'
+        os.environ[TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME] = diff_tool
+        reporter = TextDiffReporter()
+        command = reporter.get_command(approved_path, received_path)
+        self.assertEqual(command, [diff_tool, approved_path, received_path])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -9,6 +9,12 @@ class TextDiffReportertests(unittest.TestCase):
     def set_environment_variable(name, value):
         os.environ[name] = value
 
+    @staticmethod
+    def instantiate_reporter_for_test():
+        reporter = TextDiffReporter()
+        reporter.run_command = lambda command_array: None
+        return reporter
+
     @property
     def tmp_dir(self):
         test_dir = os.path.dirname(os.path.realpath(__file__))
@@ -37,12 +43,14 @@ class TextDiffReportertests(unittest.TestCase):
             TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME,
             self.diff_tool
         )
+        open(self.received_file_path, 'w').close()
+
 
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
 
     def test_constructs_valid_diff_command(self):
-        reporter = TextDiffReporter()
+        reporter = self.instantiate_reporter_for_test()
         command = reporter.get_command(
             self.approved_file_path,
             self.received_file_path
@@ -57,7 +65,7 @@ class TextDiffReportertests(unittest.TestCase):
     def test_empty_approved_file_created_when_one_does_not_exist(self):
         self.assertFileDoesNotExist(self.approved_file_path)
 
-        reporter = TextDiffReporter()
+        reporter = self.instantiate_reporter_for_test()
         reporter.report(self.approved_file_path, self.received_file_path)
 
         self.assertFileIsEmpty(self.approved_file_path)
@@ -66,7 +74,7 @@ class TextDiffReportertests(unittest.TestCase):
         approved_contents = "Approved"
         with open(self.approved_file_path, 'w') as approved_file:
             approved_file.write(approved_contents)
-        reporter = TextDiffReporter()
+        reporter = self.instantiate_reporter_for_test()
         reporter.report(self.approved_file_path, self.received_file_path)
 
         with open(self.approved_file_path, 'r') as approved_file:

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -11,8 +11,12 @@ class TextDiffReportertests(unittest.TestCase):
         return os.path.join(test_dir, 'tmp')
 
     def setUp(self):
-        shutil.rmtree(self.tmp_dir)
+        if os.path.exists(self.tmp_dir):
+            shutil.rmtree(self.tmp_dir)
         os.mkdir(self.tmp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
 
     def test_constructs_valid_diff_command(self):
         diff_tool = 'meld'

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -14,18 +14,24 @@ class TextDiffReportertests(unittest.TestCase):
         test_dir = os.path.dirname(os.path.realpath(__file__))
         return os.path.join(test_dir, 'tmp')
 
+    @property
+    def received_file_path(self):
+        return os.path.join(
+            self.tmp_dir,
+            'received_file.txt'
+        )
+
+    @property
+    def approved_file_path(self):
+        return os.path.join(
+            self.tmp_dir,
+            'approved_file.txt'
+        )
+
     def setUp(self):
         if os.path.exists(self.tmp_dir):
             shutil.rmtree(self.tmp_dir)
         os.mkdir(self.tmp_dir)
-        self.received_file_path = os.path.join(
-            self.tmp_dir,
-            'received_file.txt'
-        )
-        self.approved_file_path = os.path.join(
-            self.tmp_dir,
-            'approved_file.txt'
-        )
         self.diff_tool = 'echo'
         self.set_environment_variable(
             TextDiffReporter.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME,

--- a/src/TextDiffReporterTests.py
+++ b/src/TextDiffReporterTests.py
@@ -30,8 +30,16 @@ class TextDiffReportertests(unittest.TestCase):
 
     def test_constructs_valid_diff_command(self):
         reporter = TextDiffReporter()
-        command = reporter.get_command(self.approved_file_path, self.received_file_path)
-        self.assertEqual(command, [self.diff_tool, self.approved_file_path, self.received_file_path])
+        command = reporter.get_command(
+            self.approved_file_path,
+            self.received_file_path
+        )
+        expected_command = [
+            self.diff_tool,
+            self.approved_file_path,
+            self.received_file_path
+        ]
+        self.assertEqual(command, expected_command)
 
     def test_empty_approved_file_created_when_one_does_not_exist(self):
         self.assertFileDoesNotExist(self.approved_file_path)


### PR DESCRIPTION
Hi,

I've added a new reporter that uses a diff tool specified in an environment variable (see examples/).  I've tested this in Windows and Linux.
I also had to change one of the existing tests and its associated implementation because "\\" was hard-coded and this doesn't work on Linux.
Let me know if you have any suggestions/want to talk over any of the the changes.
Thanks,

Tim