### PR TITLE
Tdpreece/python27 compatibility

### DIFF
--- a/approvaltests/GenericDiffReporterFactory.py
+++ b/approvaltests/GenericDiffReporterFactory.py
@@ -23,7 +23,13 @@ class GenericDiffReporterFactory(object):
 
     def save(self, file_name):
         with open(file_name, 'w') as f:
-            json.dump(self.reporters, f, sort_keys=True, indent=2)
+            json.dump(
+                self.reporters,
+                f,
+                sort_keys=True,
+                indent=2,
+                separators=(',', ': ')
+            )
         return file_name
 
     def load(self, file_name):

--- a/approvaltests/TextDiffReporter.py
+++ b/approvaltests/TextDiffReporter.py
@@ -11,4 +11,4 @@ class TextDiffReporter(GenericDiffReporter):
         if self.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME not in os.environ:
             raise ReporterMissingException(self.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME)
         diff_tool = os.environ[self.DIFF_TOOL_ENVIRONMENT_VARIABLE_NAME]
-        super().__init__(('Custom', diff_tool))
+        super(TextDiffReporter, self).__init__(('Custom', diff_tool))

--- a/tests/test_genericdiffreporter.py
+++ b/tests/test_genericdiffreporter.py
@@ -14,7 +14,7 @@ class GenericDiffReporterTests(unittest.TestCase):
         self.reporter = self.factory.get_first_working()
 
     def test_list_configured_reporters(self):
-        verify(json.dumps(self.factory.list(), sort_keys=True, indent=4), self.reporter)
+        verify(json.dumps(self.factory.list(), sort_keys=True, indent=4, separators=(',', ': ')), self.reporter)
 
     def test_get_reporter(self):
         verify(str(self.factory.get("BeyondCompare4")), self.reporter)
@@ -87,7 +87,7 @@ class GenericDiffReporterTests(unittest.TestCase):
         namer = Namer(1)
         full_name = os.path.join(namer.get_directory(), 'custom-reporters.json')
         reporters = self.factory.load(full_name)
-        verify(json.dumps(reporters, sort_keys=True, indent=4), self.reporter)
+        verify(json.dumps(reporters, sort_keys=True, indent=4, separators=(',', ': ')), self.reporter)
 
     def test_notworking_in_environment(self):
         reporter = GenericDiffReporter(('Custom', 'NotReal'))
@@ -99,4 +99,4 @@ class GenericDiffReporterTests(unittest.TestCase):
 
     def test_remove_reporter(self):
         self.factory.remove("meld")
-        verify(json.dumps(self.factory.list(), sort_keys=True, indent=4), self.reporter)
+        verify(json.dumps(self.factory.list(), sort_keys=True, indent=4, separators=(',', ': ')), self.reporter)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py34
+
+[testenv]
+commands = python -m unittest discover -s tests/ -p "*.py" {posargs}


### PR DESCRIPTION
Hi,

I have added a tox.ini file so that it's easier to to run the tests against both Python 2.7 and Python 3.4 (https://tox.readthedocs.org/en/latest/).  After installing tox you can run the tests by running "tox" on the command line.
I have also made changes so that ApprovalTests works for Python 2.7 and Python 3.4.
Please let me know if there's anything that you'd like changing, if you have any questions or if you just want to talk over the changes.  Thanks,

Tim