### PR TITLE
Add pytest as test dependency in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,5 @@
 envlist = py27,py34
 
 [testenv]
+deps=pytest
 commands = python -m unittest discover -s tests/ -p "*.py" {posargs}


### PR DESCRIPTION
Attempt to fix the build that we broke in 17a167dbb7cbcf7fa1b4ada52419c883bc4dcb4b.

@isidore