### PR TITLE
Fix missing approvaltests.reporters submodule when installing package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.core import setup
+from setuptools import find_packages
 
 setup(
     name='approvaltests',
@@ -7,7 +8,7 @@ setup(
     author='ApprovalTests Contributors',
     author_email='jamesrcounts@outlook.com',
     url='https://github.com/approvals/ApprovalTests.Python',
-    packages=['approvaltests'],
+    packages=find_packages(exclude=['tests*']),
     package_data={'approvaltests':['reporters.json']},
     install_requires=['pyperclip==1.5.27',],
 )


### PR DESCRIPTION
setup.py is missing approvaltests.reporters submodule, causing "setup.py build" to build an incomplete package