### PR TITLE
Issue 10 fix: Get approvaltests working when pytest isn't installed.

### DIFF
--- a/approvaltests/Namer.py
+++ b/approvaltests/Namer.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-import pytest
 
 
 class Namer(object):

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,4 @@
 envlist = py27,py34
 
 [testenv]
-deps=pytest
 commands = python -m unittest discover -s tests/ -p "*.py" {posargs}


### PR DESCRIPTION
Supporting pytest tests doesn't require pytest to be a dependency of
approvaltests (see `Namer.is_test_method`) thus we don't need to
import pytest in the Namer.py module.