### PR TITLE
Add kdiff3

### DIFF
--- a/approvaltests/reporters/reporters.json
+++ b/approvaltests/reporters/reporters.json
@@ -28,6 +28,10 @@
     "C:/Program Files (x86)/WinMerge/WinMergeU.exe"
   ],
   [
+    "kdiff3",
+    "/usr/bin/kdiff3"
+  ],
+  [
     "vimdiff",
     "/usr/bin/vimdiff"
   ],

--- a/tests/approved_files/GenericDiffReporterTests.test_list_configured_reporters.approved.txt
+++ b/tests/approved_files/GenericDiffReporterTests.test_list_configured_reporters.approved.txt
@@ -6,6 +6,7 @@
     "AraxisMergeWin",
     "AraxisMergeMac",
     "WinMerge",
+    "kdiff3",
     "vimdiff",
     "meld",
     "opendiff",

--- a/tests/approved_files/GenericDiffReporterTests.test_remove_reporter.approved.txt
+++ b/tests/approved_files/GenericDiffReporterTests.test_remove_reporter.approved.txt
@@ -6,6 +6,7 @@
     "AraxisMergeWin",
     "AraxisMergeMac",
     "WinMerge",
+    "kdiff3",
     "vimdiff",
     "opendiff",
     "DiffMerge"

--- a/tests/approved_files/GenericDiffReporterTests.test_serialization.approved.txt
+++ b/tests/approved_files/GenericDiffReporterTests.test_serialization.approved.txt
@@ -28,6 +28,10 @@
     "C:/Program Files (x86)/WinMerge/WinMergeU.exe"
   ],
   [
+    "kdiff3",
+    "/usr/bin/kdiff3"
+  ],
+  [
     "vimdiff",
     "/usr/bin/vimdiff"
   ],

--- a/tests/saved-reporters.json
+++ b/tests/saved-reporters.json
@@ -28,6 +28,10 @@
     "C:/Program Files (x86)/WinMerge/WinMergeU.exe"
   ],
   [
+    "kdiff3",
+    "/usr/bin/kdiff3"
+  ],
+  [
     "vimdiff",
     "/usr/bin/vimdiff"
   ],


### PR DESCRIPTION
I added kdiff3 as a gui-diff-tool before the first low-level-diff-tool vim-diff.
(kdiff3 is my favourite tool for approval-tests, I am completely unable to work with vim-diff ;) )