### PR TITLE
use to_json in some more places (DRY)

### DIFF
--- a/approvaltests/reporters/generic_diff_reporter.py
+++ b/approvaltests/reporters/generic_diff_reporter.py
@@ -4,6 +4,7 @@ import subprocess
 
 from approvaltests.command import Command
 from approvaltests.core.reporter import Reporter
+from approvaltests.utils import to_json
 
 
 class GenericDiffReporter(Reporter):
@@ -26,12 +27,7 @@ class GenericDiffReporter(Reporter):
         }
         if self.extra_args:
             config.update({"arguments": self.extra_args})
-        return json.dumps(
-            config,
-            indent=4,
-            sort_keys=True,
-            separators=(',', ': ')
-        )
+        return to_json(config)
 
     @staticmethod
     def create_empty_file(file_path):

--- a/tests/test_genericdiffreporter.py
+++ b/tests/test_genericdiffreporter.py
@@ -7,7 +7,7 @@ from approvaltests.approvals import verify
 from approvaltests.reporters.generic_diff_reporter import GenericDiffReporter
 from approvaltests.reporters.generic_diff_reporter_factory import GenericDiffReporterFactory
 from approvaltests.core.namer import Namer
-
+from approvaltests.utils import to_json
 
 class GenericDiffReporterTests(unittest.TestCase):
     def setUp(self):
@@ -21,7 +21,7 @@ class GenericDiffReporterTests(unittest.TestCase):
         shutil.rmtree(self.tmp_dir)
 
     def test_list_configured_reporters(self):
-        verify(json.dumps(self.factory.list(), sort_keys=True, indent=4, separators=(',', ': ')), self.reporter)
+        verify(to_json(self.factory.list()), self.reporter)
 
     def test_get_reporter(self):
         verify(str(self.factory.get("BeyondCompare4")), self.reporter)
@@ -94,7 +94,7 @@ class GenericDiffReporterTests(unittest.TestCase):
         namer = Namer()
         full_name = os.path.join(namer.get_directory(), 'custom-reporters.json')
         reporters = self.factory.load(full_name)
-        verify(json.dumps(reporters, sort_keys=True, indent=4, separators=(',', ': ')), self.reporter)
+        verify(to_json(reporters), self.reporter)
 
     def test_notworking_in_environment(self):
         reporter = GenericDiffReporter(('Custom', 'NotReal'))
@@ -106,7 +106,7 @@ class GenericDiffReporterTests(unittest.TestCase):
 
     def test_remove_reporter(self):
         self.factory.remove("meld")
-        verify(json.dumps(self.factory.list(), sort_keys=True, indent=4, separators=(',', ': ')), self.reporter)
+        verify(to_json(self.factory.list()), self.reporter)
 
     @staticmethod
     def instantiate_reporter_for_test():


### PR DESCRIPTION
I noticed json.dumps was scattered with identical parameters in some places, and that there actually was a to_json utility function nailing just those parameters.

So went ahead and DRYed the code up ever so slightly.

