### PR TITLE
change travis to use pytest instead of unittest

### DIFF
--- a/approvaltests/reporters/generic_diff_reporter_factory.py
+++ b/approvaltests/reporters/generic_diff_reporter_factory.py
@@ -11,9 +11,6 @@ class GenericDiffReporterFactory(object):
         self.load(get_adjacent_file('reporters.json'))
         self.add_fallback_reporter_config(["PythonNative", "python", [get_adjacent_file("python_native_reporter.py")]])
 
-    def add_default_reporter_config(self, config):
-        self.reporters.insert(0, config)
-
     def add_fallback_reporter_config(self, config):
         self.reporters.append(config)
 

--- a/approvaltests/reporters/python_native_reporter.py
+++ b/approvaltests/reporters/python_native_reporter.py
@@ -14,10 +14,10 @@ def calculate_diff(file1, file2):
     else:
         with open(file1) as f1:
             with open(file2) as f2:
-                diff = unified_diff(f1.readlines(),
-                                    f2.readlines(),
-                                    os.path.basename(file1),
-                                    os.path.basename(file2))
+                diff = unified_diff(f2.readlines(),
+                                    f1.readlines(),
+                                    os.path.basename(file2),
+                                    os.path.basename(file1))
                 diff_string = "\n".join(diff)
                 approve = get_command_text(file1, file2)
                 approve_cmd = "\n\nto approve this result:\n\n" + approve + "\n"

--- a/approvaltests/reporters/python_native_reporter.py
+++ b/approvaltests/reporters/python_native_reporter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import filecmp
 import os
 import sys
 from difflib import unified_diff
@@ -9,19 +8,19 @@ from approvaltests.reporters import get_command_text
 
 
 def calculate_diff(file1, file2):
-    if filecmp.cmp(file1, file2):
-        return "Files are identical"
-    else:
-        with open(file1) as f1:
-            with open(file2) as f2:
-                diff = unified_diff(f2.readlines(),
-                                    f1.readlines(),
-                                    os.path.basename(file2),
-                                    os.path.basename(file1))
-                diff_string = "\n".join(diff)
+    with open(file1) as f1:
+        with open(file2) as f2:
+            diff = unified_diff(f2.readlines(),
+                                f1.readlines(),
+                                os.path.basename(file2),
+                                os.path.basename(file1))
+            diff_string = "\n".join(diff)
+            if diff_string.strip():
                 approve = get_command_text(file1, file2)
                 approve_cmd = "\n\nto approve this result:\n\n" + approve + "\n"
-                return diff_string + approve_cmd
+            else:
+                approve_cmd = ""
+            return diff_string + approve_cmd
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     url='https://github.com/approvals/ApprovalTests.Python',
     packages=find_packages(exclude=['tests*']),
     package_data={'approvaltests':['reporters/reporters.json']},
-    install_requires=['pyperclip==1.5.27',],
+    install_requires=['pyperclip==1.5.27', 'pytest'],
 )

--- a/tests/reporters/approved_files/test_python_native_reporter.test_files_differ.approved.txt
+++ b/tests/reporters/approved_files/test_python_native_reporter.test_files_differ.approved.txt
@@ -1,11 +1,11 @@
---- a.received.txt
+--- b.approved.txt
 
-+++ b.approved.txt
++++ a.received.txt
 
 @@ -1 +1 @@
 
--abc
-+def
+-def
++abc
 
 to approve this result:
 

--- a/tests/reporters/test_python_native_reporter.py
+++ b/tests/reporters/test_python_native_reporter.py
@@ -5,6 +5,8 @@ from approvaltests.reporters import GenericDiffReporterFactory
 
 from approvaltests.reporters.python_native_reporter import *
 
+factory = GenericDiffReporterFactory()
+
 
 def test_files_identical(tmpdir):
     file1 = os.path.join(str(tmpdir), "a.received.txt")
@@ -14,7 +16,7 @@ def test_files_identical(tmpdir):
         f1.write(identical_contents)
     with open(file2, "w") as f2:
         f2.write(identical_contents)
-    assert calculate_diff(file1, file2) == "Files are identical"
+    verify(calculate_diff(file1, file2), reporter=factory.get("PythonNative"))
 
 
 def test_files_differ(tmpdir):
@@ -27,6 +29,5 @@ def test_files_differ(tmpdir):
     diff = calculate_diff(file1, file2)
     diff = diff.replace(str(tmpdir), "tmpdir")
 
-    factory = GenericDiffReporterFactory()
     verify(diff, reporter=factory.get("PythonNative"))
 

--- a/tests/reporters/test_python_native_reporter.py
+++ b/tests/reporters/test_python_native_reporter.py
@@ -1,6 +1,7 @@
 import os
 
 from approvaltests import verify
+from approvaltests.reporters import GenericDiffReporterFactory
 
 from approvaltests.reporters.python_native_reporter import *
 
@@ -25,5 +26,7 @@ def test_files_differ(tmpdir):
         f2.write("def")
     diff = calculate_diff(file1, file2)
     diff = diff.replace(str(tmpdir), "tmpdir")
-    verify(diff)
+
+    factory = GenericDiffReporterFactory()
+    verify(diff, reporter=factory.get("PythonNative"))
 

--- a/tests/reporters/test_python_native_reporter.py
+++ b/tests/reporters/test_python_native_reporter.py
@@ -6,8 +6,8 @@ from approvaltests.reporters.python_native_reporter import *
 
 
 def test_files_identical(tmpdir):
-    file1 = os.path.join(tmpdir, "a.received.txt")
-    file2 = os.path.join(tmpdir, "b.approved.txt")
+    file1 = os.path.join(str(tmpdir), "a.received.txt")
+    file2 = os.path.join(str(tmpdir), "b.approved.txt")
     identical_contents = "abc"
     with open(file1, "w") as f1:
         f1.write(identical_contents)
@@ -17,8 +17,8 @@ def test_files_identical(tmpdir):
 
 
 def test_files_differ(tmpdir):
-    file1 = os.path.join(tmpdir, "a.received.txt")
-    file2 = os.path.join(tmpdir, "b.approved.txt")
+    file1 = os.path.join(str(tmpdir), "a.received.txt")
+    file2 = os.path.join(str(tmpdir), "b.approved.txt")
     with open(file1, "w") as f1:
         f1.write("abc")
     with open(file2, "w") as f2:

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,4 @@ envlist = py27,py36,py37
 changedir = './tests/'
 
 [testenv]
-changedir=tests
-commands = python -m unittest discover -s . -p "*.py" {posargs}
+commands = python -m pytest


### PR DESCRIPTION
## Description

Not all tests were being run in travis ci since some were written with pytest

## The solution

in tox.ini, use pytest instead of unittest as a test runner. It should run all the tests not just the unittest ones.
