### PR TITLE
added 'verify_xml' function and associated test case.

### DIFF
--- a/approvaltests/approvals.py
+++ b/approvaltests/approvals.py
@@ -1,4 +1,5 @@
 from threading import local
+import xml.dom.minidom
 
 from approvaltests import to_json
 from approvaltests.approval_exception import ApprovalException
@@ -20,6 +21,7 @@ def get_default_reporter():
     if not hasattr(DEFAULT_REPORTER, "v") or DEFAULT_REPORTER.v is None:
         return DiffReporter()
     return DEFAULT_REPORTER.v
+
 
 def get_reporter(reporter):
     if reporter is None:
@@ -49,10 +51,20 @@ def verify_as_json(object, reporter=None):
     verify(n_, reporter)
 
 
+def verify_xml(xml_string, reporter=None):
+    try:
+        dom = xml.dom.minidom.parseString(xml_string)
+        pretty_xml = dom.toprettyxml()
+    except Exception:
+        pretty_xml = xml_string
+    verify_with_namer(pretty_xml, Namer(extension='.xml'), reporter)
+
+
 def verify_file(file_name, reporter=None):
     with open(file_name, 'r') as f:
         file_contents = f.read()
     verify(file_contents, reporter)
+
 
 def verify_all(header, alist, formatter=None, reporter=None):
     text = format_list(alist, formatter, header)

--- a/tests/approved_files/VerifyTests.test_verify_xml.approved.xml
+++ b/tests/approved_files/VerifyTests.test_verify_xml.approved.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<orderHistory createdAt="2019-08-02T16:40:18.109470">
+	<order date="2018-09-01T00:00:00+00:00" totalDollars="149.99">
+		<product id="EVENT02">Makeover</product>
+	</order>
+	<order date="2017-09-01T00:00:00+00:00" totalDollars="14.99">
+		<product id="LIPSTICK01">Cherry Bloom</product>
+	</order>
+</orderHistory>

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,7 +1,7 @@
 import unittest
 
 from approvaltests.approval_exception import ApprovalException
-from approvaltests.approvals import verify, verify_as_json, verify_file
+from approvaltests.approvals import verify, verify_as_json, verify_file, verify_xml
 from approvaltests.reporters.generic_diff_reporter_factory import GenericDiffReporterFactory
 from approvaltests.reporters.testing_reporter import ReporterForTesting
 from approvaltests.utils import get_adjacent_file
@@ -39,3 +39,7 @@ class VerifyTests(unittest.TestCase):
         name = "testFile.txt"
         filename = get_adjacent_file(name)
         verify_file(filename, self.reporter)
+
+    def test_verify_xml(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?><orderHistory createdAt='2019-08-02T16:40:18.109470'><order date='2018-09-01T00:00:00+00:00' totalDollars='149.99'><product id='EVENT02'>Makeover</product></order><order date='2017-09-01T00:00:00+00:00' totalDollars='14.99'><product id='LIPSTICK01'>Cherry Bloom</product></order></orderHistory>"""
+        verify_xml(xml)


### PR DESCRIPTION
## 'verify_xml' function added

For when you have xml you want to verify. It will store it in a file with a .xml extension, and prettify the xml to make it easier to diff.

## The solution

I added a top level function in the approvals module. I'm using xml.dom.minidom (which is in the standard python library) to prettify the xml. If I am unable to prettify I just use the xml string that came in.



