### PR TITLE
Run tests on Python 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
+    - python: 3.8
+      env: TOXENV=py38
+      dist: xenial
+      sudo: true
     - python: 2.7
       env: TOXENV=py27
 before_install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37
+envlist = py27,py36,py37,py38
 changedir = './tests/'
 
 [testenv]


### PR DESCRIPTION
Extends tox and travis configurations to runs tests on Python 3.8.
