### PR TITLE
Add support to approve and verify binary data

### DIFF
--- a/approvaltests/binary_writer.py
+++ b/approvaltests/binary_writer.py
@@ -1,0 +1,19 @@
+import io
+
+from approvaltests.core import Writer
+
+
+class BinaryWriter(Writer):
+    contents = ''
+
+    def __init__(self, contents):
+        self.contents = contents
+
+    def _write_content_to_file(self, received_file):
+        with io.open(
+            received_file,
+            mode='wb'
+        ) as f:
+            f.write(self.contents)
+
+        return received_file

--- a/approvaltests/core/writer.py
+++ b/approvaltests/core/writer.py
@@ -1,5 +1,18 @@
+import os
+
+
 class Writer(object):
     # interface
 
     def write_received_file(self, received_file):
+        self.create_directory_if_needed(received_file)
+        self._write_content_to_file(received_file)
+
+    def _write_content_to_file(self, received_file):
         raise Exception("Interface member not implemented")
+
+    @staticmethod
+    def create_directory_if_needed(received_file):
+        directory = os.path.dirname(received_file)
+        if directory and not os.path.exists(directory):
+            os.makedirs(directory)

--- a/approvaltests/string_writer.py
+++ b/approvaltests/string_writer.py
@@ -17,8 +17,7 @@ class StringWriter(Writer):
         self.errors = errors
         self.newline = newline
 
-    def write_received_file(self, received_file):
-        self.create_directory_if_needed(received_file)
+    def _write_content_to_file(self, received_file):
         with io.open(
                 received_file,
                 mode='wt',
@@ -28,9 +27,3 @@ class StringWriter(Writer):
         ) as f:
             f.write(self.contents)
         return received_file
-
-    @staticmethod
-    def create_directory_if_needed(received_file):
-        directory = os.path.dirname(received_file)
-        if directory and not os.path.exists(directory):
-            os.makedirs(directory)

--- a/docs/verify-binary.md
+++ b/docs/verify-binary.md
@@ -1,0 +1,78 @@
+# Verify Binary Blobs
+
+Using the `verify_binary` function, you can also check binary data blobs. For instance, you could check that your 
+program produces correct image frames. Another example would be approving and checking numpy arrays in scientific 
+applications.
+
+## Examples
+
+### Approving images
+In this example, you can see how `verify_binary` is used to approve rendered images. The file endings are also adjusted 
+instead of using the generic `.blb` extension. Hence, it is easier to inspect them, using any image viewer. In any case, 
+it is important to configure a reporter which can parse and compare binary data properly (i.e. in most Unix 
+environments plain old `diff`). See [configuration](configuration.md) for more details on that.
+
+```python
+from approvaltests import verify_binary, get_default_namer
+
+
+def verify_ppm(ppm_data):
+    verify_binary(ppm_data, namer=get_default_namer(extension='.ppm'))
+
+
+def test_render_to_ppm_file(render_engine):
+    verify_ppm(render_engine.render().as_ppm())
+```
+
+### Approving NumPy arrays
+This more detailed example demonstrates how you could use `verify_binary` to approve NumPy arrays. It also shows the 
+use of a custom reporter. It uses the NumPy testing features to produce a well-formatted error report highlighting the 
+differences between arrays. Additionally, it shows you how to use serializers instead of dumping the binary blob 
+directly to disk. In this case, the serialization provided by NumPy is used.
+
+```python
+import io
+from pathlib import Path
+
+import numpy as np
+from approvaltests import verify_binary
+from approvaltests.core import Reporter
+
+# Serialization for numpy arrays so approved arrays can be stored and committed to the repository
+def serialize_ndarray(a: np.ndarray):
+    bs = io.BytesIO()
+    np.save(bs, a)
+    bs.seek(0)
+    return bs.read()
+
+
+def deserialize_ndarray(path):
+    with open(path, mode='rb') as f:
+        return np.load(f)
+
+
+# Use a custom reporter to show the assertion message from numpy
+# Also the default python console reporter will try to interpret the numpy data as text causing an error
+class NDArrayDiffReporter(Reporter):
+    def report(self, received_path, approved_path):
+        if not Path(approved_path).is_file():
+            self._create_empty_array(approved_path)
+
+        received = deserialize_ndarray(received_path)
+        approved = deserialize_ndarray(approved_path)
+        to_approve_msg = f"To approve run:\nmv -f {received_path} {approved_path}"
+        print(np.testing.build_err_msg([received, approved], err_msg=to_approve_msg))
+
+    @staticmethod
+    def _create_empty_array(path):
+        with open(path, mode='wb') as f:
+            f.write(serialize_ndarray(np.zeros((0,))))
+
+
+def verify_ndarray(a: np.ndarray):
+    verify_binary(serialize_ndarray(a), reporter=NDArrayDiffReporter())
+
+
+def test_simulator_produces_correct_output(simulator):
+    verify_ndarray(simulator.step())
+```

--- a/tests/approved_files/VerifyTests.test_verify_binary.approved.blb
+++ b/tests/approved_files/VerifyTests.test_verify_binary.approved.blb
@@ -1,0 +1,1 @@
+Hello World.

--- a/tests/approved_files/VerifyTests.test_verify_binary_file.approved.blb
+++ b/tests/approved_files/VerifyTests.test_verify_binary_file.approved.blb
@@ -1,0 +1,4 @@
+contests of a test binary file
+could be for instance an image format
+in this case it just contains
+DEADBEAF

--- a/tests/exampleFile.blb
+++ b/tests/exampleFile.blb
@@ -1,0 +1,4 @@
+contests of a test binary file
+could be for instance an image format
+in this case it just contains
+DEADBEAF

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,7 +3,7 @@
 import unittest
 
 from approvaltests.approval_exception import ApprovalException
-from approvaltests.approvals import verify, verify_as_json, verify_file, verify_xml
+from approvaltests.approvals import verify, verify_as_json, verify_file, verify_xml, verify_binary, verify_binary_file
 from approvaltests.reporters.generic_diff_reporter_factory import GenericDiffReporterFactory
 from approvaltests.reporters.testing_reporter import ReporterForTesting
 from approvaltests.utils import get_adjacent_file
@@ -15,7 +15,7 @@ class VerifyTests(unittest.TestCase):
 
     def test_verify(self):
         verify("Hello World.", self.reporter)
-        
+
     def test_verify_with_encoding(self):
         verify(u"Høvdingens kjære squaw får litt pizza i Mexico by", self.reporter, encoding="utf-8")
 
@@ -24,7 +24,8 @@ class VerifyTests(unittest.TestCase):
             verify(u"Høvdingens kjære squaw får litt pizza i Mexico by", self.reporter, encoding="ascii")
 
     def test_verify_with_errors_replacement_character(self):
-        verify(u"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg", self.reporter, encoding="ascii", errors="replace")
+        verify(u"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg", self.reporter, encoding="ascii",
+               errors="replace")
 
     def test_verify_with_newlines(self):
         verify(
@@ -71,3 +72,19 @@ class VerifyTests(unittest.TestCase):
     def test_verify_xml(self):
         xml = """<?xml version="1.0" encoding="UTF-8"?><orderHistory createdAt='2019-08-02T16:40:18.109470'><order date='2018-09-01T00:00:00+00:00' totalDollars='149.99'><product id='EVENT02'>Makeover</product></order><order date='2017-09-01T00:00:00+00:00' totalDollars='14.99'><product id='LIPSTICK01'>Cherry Bloom</product></order></orderHistory>"""
         verify_xml(xml)
+
+    def test_verify_binary(self):
+        verify_binary(b"Hello World.", self.reporter)
+
+    def test_verify_binary_fail(self):
+        reporter = ReporterForTesting()
+        try:
+            verify_binary(b"Hello World.", reporter)
+            self.assertFalse(True, "expected exception")
+        except ApprovalException as e:
+            self.assertTrue("Approval Mismatch", e.value)
+
+    def test_verify_binary_file(self):
+        name = "exampleFile.blb"
+        filename = get_adjacent_file(name)
+        verify_binary_file(filename, self.reporter)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,6 +1,8 @@
 ﻿import os
+import struct
 from random import randint
 
+from approvaltests.binary_writer import BinaryWriter
 from approvaltests.string_writer import StringWriter
 
 
@@ -21,4 +23,24 @@ def test_writes_file_to_missing_directory(tmpdir):
     sw.write_received_file(filename)
 
     with open(filename, 'r') as received:
+        assert contents == received.read()
+
+
+def test_writes_binary_file(tmpdir):
+    contents = b"foo" + struct.pack('B', randint(0, 100))
+    bw = BinaryWriter(contents)
+    filename = os.path.join(str(tmpdir), 'stuff.blb')
+    bw.write_received_file(filename)
+
+    with open(filename, 'rb') as received:
+        assert contents == received.read()
+
+
+def test_writes_binary_file_to_missing_directory(tmpdir):
+    contents = b"foo"
+    bw = BinaryWriter(contents)
+    filename = os.path.join(str(tmpdir), 'non_existent_folder', './stuff.blb')
+    bw.write_received_file(filename)
+
+    with open(filename, 'rb') as received:
         assert contents == received.read()


### PR DESCRIPTION
## Description

The PR adds support for verifying binary data such as images or NumPy arrays. I've extended the framework because I required a means to compare NumPy arrays. However, to not force NumPy on users, I've implemented a generic `verify_binary` functions. Now, this can also be used, for instance, to verify image data. 

Anyways, I thought this might be of use to others as well, especially those developing scientific software (there's NumPy everywhere).

## The solution

I've extended the approvals by a `verify_binary` and a `verify_binary_file` function. These have the same interface as their textual counterparts. To handle the binary data itself and to avoid encoding it I've added the `BinaryWriter` class. The only real difference to the `StringWriter` is that it does write in binary mode and doesn't perform any encoding. To reduce code duplication, I've extracted the common logic of `BinaryWriter` and `StringWriter` into a parent Writer class.

No existing tests are affected, however tests for `verify_binary` and `BinaryWriter` have been added to test_verify.py and test_writer.py.

I've also added examples to the doc to illustrate how I'm using this feature.