### PR TITLE
t Windows CI using AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+environment:
+  matrix:
+    - TOXENV: py27
+    - TOXENV: py36
+    - TOXENV: py37
+    - TOXENV: py38
+
+build: off
+
+install:
+- choco install meld
+- pip install tox
+
+test_script:
+- tox

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,5 @@ envlist = py27,py36,py37,py38
 changedir = './tests/'
 
 [testenv]
+deps = pytest
 commands = python -m pytest


### PR DESCRIPTION
## Description

CI for Windows using AppVeyor. Tries to mirror `.travis.yml` closely.

One thing I am not sure about: Should the `pytest` dependency be stated in `tox.ini` or should it be installed explicitly in the CI config?

See the results here: https://ci.appveyor.com/project/fleimgruber/approvaltests-python.

closes #39