### PR TITLE
Fix SyntaxWarning in StackFrameName.get_config

### DIFF
--- a/approvaltests/core/namer.py
+++ b/approvaltests/core/namer.py
@@ -73,8 +73,8 @@ class StackFrameNamer(Namer):
     def is_test_method(self, frame):
         is_unittest_test = ("self" in frame[0].f_locals
                and "_testMethodName" in frame[0].f_locals["self"].__dict__
-               and frame[3] is not "__call__"
-               and frame[3] is not "run")
+               and frame[3] != "__call__"
+               and frame[3] != "run")
 
         is_pytest_test = frame[3].startswith("test_")
 


### PR DESCRIPTION
There was a SyntaxWarning when running pytest regarding the use of 'is not' for literals. The 'is not' operator is reserved for checking that objects do not share the same identity. As strings are immutable in Python, It could be possible for two equal strings not to have the same identity. 

I've simply changed the two uses of the 'is not' operator to the != operator as suggested by the SyntaxWarning. 

