### PR TITLE
fix SyntaxWarnings: "is not" with a literal

### DIFF
--- a/approvaltests/core/namer.py
+++ b/approvaltests/core/namer.py
@@ -73,8 +73,8 @@ class StackFrameNamer(Namer):
     def is_test_method(self, frame):
         is_unittest_test = ("self" in frame[0].f_locals
                and "_testMethodName" in frame[0].f_locals["self"].__dict__
-               and frame[3] is not "__call__"
-               and frame[3] is not "run")
+               and frame[3] != "__call__"
+               and frame[3] != "run")
 
         is_pytest_test = frame[3].startswith("test_")
 


### PR DESCRIPTION
Whenever I use pytest with approvals, I get these warnings which I think should be easily fixed

    . .venv/bin/activate; PYTHONPATH=. py.test --color=yes tests/approval --approvaltests-use-reporter=PythonNative
    /home/ceda/some/project/aws-lambdas-and-events/.venv/lib/python3.8/site-packages/approvaltests/core/namer.py:76: SyntaxWarning: "is not" with a literal. Did you mean "!="?
      and frame[3] is not "__call__"
    /home/ceda/some/project/aws-lambdas-and-events/.venv/lib/python3.8/site-packages/approvaltests/core/namer.py:77: SyntaxWarning: "is not" with a literal. Did you mean "!="?
      and frame[3] is not "run")

## Description

Removes SyntaxWarnings test runs (when run with Python3.8+), removing the clutter/noise this framework creates each test run.

## The solution

Change `is not` to `!=`.

## Background

From Python 3.8 Release notes:

> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in bpo-34850.)

Further reading, with extract from [the bug report](https://bugs.python.org/issue34850) leading up to this compiler warning

> Gregory have noticed that the "is" and "is not" operator sometimes is used with string and numerical literals. This code "works" on CPython by accident, because of caching on different levels (small integers and strings caches, interned strings, deduplicating constants at compile time). But it shouldn't work on other implementations, and can not work even on early or future CPython versions.