### PR TITLE
e   run tests with github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [2.7, 3.6, 3.7, 3.8]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+          pip install pytest
+      - name: Test
+        run: |
+          tox -e py  # Run tox using the version of Python in `PATH`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Capturing Human Intelligence - ApprovalTests is an open source assertion/verific
 
 For more information see: [www.approvaltests.com](http://approvaltests.com/).
 
-[![Build Status](https://travis-ci.org/approvals/ApprovalTests.Python.png?branch=master)](https://travis-ci.org/approvals/ApprovalsTests.Python)
+Travis CI: [![Build Status](https://travis-ci.org/approvals/ApprovalTests.Python.png?branch=master)](https://travis-ci.org/approvals/ApprovalsTests.Python)
+
+Github Actions: [![Build Status](https://github.com/approvals/ApprovalTests.Python/workflows/Test/badge.svg?branch=master)](https://github.com/approvals/ApprovalTests.Python/actions)
 
 ## What can I use ApprovalTests for?
 


### PR DESCRIPTION
This commit will result in github Actions running the test suite on push and
pull requests. Tests are run across the same Python versions as the current
Travis CI config and are run on both ubuntu and macos. Tests on windows
failed but fixing up the Windows tests is for another day.

The .NET, C++ and Java libraries have started to use github actions for
various purposes. I think that it is worth trialing github actions
because:

* deployments seem more configurable, which should make the path to automatic
  deployments of this package smoother (I can't see a way of deploying to
  test.pypi.org from Travis CI).
* this test workflow has been configured to run on all pushes, which
  makes it easier for devs to test enhancements to the CI/CD process on
  their forks.

"GitHub Actions usage is free for public repositories" see
https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions