### PR TITLE
e   publish to test.pypi.org on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload --repository-url https://test.pypi.org/legacy/ dist/*


### PR DESCRIPTION
Adds GitHub Actions workflow that will publish this package to
test.pypi.org on release. If successful we can change this to push to
the real pypi.org.

Setup that needs to be done before this is merged:
[ ] login to https://test.pypi.org and create a token for this project
[ ] add a GitHub secret for this token with the name TEST_PYPI_PASSWORD

Once merged we can create a release that will push to test.pypi by:
* browsing to https://github.com/approvals/ApprovalTests.Python
* "Releases" > "Draft a new release"
* entering a new tag version in the box
* clicking "Publish release"
* click the "actions" tab to see how the workflows went
* check https://test.pypi.org/project/approvaltests/ for new version

I had some security concerns around this approach but they are mitigated
by GitHub's controls (described below).

Threat 1: Someone could submit a pull request that leaks your tokens
(e.g. add a line like print(os.environ['SECRET_TOKEN'])).
Control: GitHub run all pull request workflows raised repository
forks with no access to secrets, see
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

Threat 2: Someone could submit a pull request that alters the
publish.yml workflow so that it publishes on the pull_request event
instead of the release created event.
Control: same as for Threat 1.