### PR TITLE
t Fix test_namer unit tests

### DIFF
--- a/tests/pytest/test_namer.py
+++ b/tests/pytest/test_namer.py
@@ -1,19 +1,21 @@
+import os
+
 from approvaltests.approvals import get_default_namer, verify
 from approvaltests.pytest.namer import PyTestNamer
 
 
-def test_basic_approval():
-    verify("foo")
-
-
 def test_received_filename():
     namer = get_default_namer()
-    assert namer.get_received_filename().endswith("ApprovalTests.Python/tests/pytest/test_namer.test_received_filename.received.txt")
+    expected = os_path("ApprovalTests.Python/tests/pytest/test_namer.test_received_filename.received.txt")
+    assert namer.get_received_filename().endswith(expected)
 
 
 def test_pytest_namer(request):
     namer = PyTestNamer(request)
-    assert namer.get_received_filename().endswith("ApprovalTests.Python/tests/pytest/test_namer.test_pytest_namer.received.txt")
+    expected = os_path("ApprovalTests.Python/tests/pytest/test_namer.test_pytest_namer.received.txt")
+    assert namer.get_received_filename().endswith(expected)
     verify("foo", namer=namer)
 
 
+def os_path(posix_path):
+    return posix_path.replace("/", os.path.sep)

--- a/tests/pytest/test_namer.py
+++ b/tests/pytest/test_namer.py
@@ -4,6 +4,10 @@ from approvaltests.approvals import get_default_namer, verify
 from approvaltests.pytest.namer import PyTestNamer
 
 
+def test_basic_approval():
+    verify("foo")
+
+
 def test_received_filename():
     namer = get_default_namer()
     expected = os_path("ApprovalTests.Python/tests/pytest/test_namer.test_received_filename.received.txt")


### PR DESCRIPTION
The O/S specific path delimiter was not grokked by the
unit tests in test_namer.py; this commit teaches them.

## Description

This change hopefully fixes 2 failing unit tests on the Windows CI build.

## The solution

The tests assumed the path delimiter of all operating systems is "/", which is not true.

2 tests in test_namer.py modified to use OS-specific path strings in verification.

