### PR TITLE
d   Add PyPI and Python version badges, and missing GitHub Actions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Capturing Human Intelligence - ApprovalTests is an open source assertion/verific
 
 For more information see: [www.approvaltests.com](http://approvaltests.com/).
 
-Github Actions: [![Build Status](https://github.com/approvals/ApprovalTests.Python/workflows/Test/badge.svg?branch=master)](https://github.com/approvals/ApprovalTests.Python/actions)
+[![PyPI version](https://img.shields.io/pypi/v/approvaltests.svg)](https://pypi.org/project/approvaltests)
+[![Python versions](https://img.shields.io/pypi/pyversions/approvaltests.svg)](https://pypi.org/project/approvaltests)
+[![Build Status](https://github.com/approvals/ApprovalTests.Python/workflows/Test/badge.svg?branch=master)](https://github.com/approvals/ApprovalTests.Python/actions)
 
 
 ## What can I use ApprovalTests for?

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ For more information see: [www.approvaltests.com](http://approvaltests.com/).
 [![PyPI version](https://img.shields.io/pypi/v/approvaltests.svg)](https://pypi.org/project/approvaltests)
 [![Python versions](https://img.shields.io/pypi/pyversions/approvaltests.svg)](https://pypi.org/project/approvaltests)
 [![Build Status](https://github.com/approvals/ApprovalTests.Python/workflows/Test/badge.svg?branch=master)](https://github.com/approvals/ApprovalTests.Python/actions)
+[![Build Status](https://github.com/approvals/ApprovalTests.Python/workflows/on-push-do-doco/badge.svg)](https://github.com/approvals/ApprovalTests.Python/actions?query=workflow%3Aon-push-do-doco)
+[![Build Status](https://github.com/approvals/ApprovalTests.Python/workflows/Upload%20Python%20Package/badge.svg)](https://github.com/approvals/ApprovalTests.Python/actions?query=workflow%3A%22Upload+Python+Package%22)
 
 
 ## What can I use ApprovalTests for?


### PR DESCRIPTION
Added badges to:

1. provide direct links to PyPI - showing current released version, and the supported Python versions
2. show status of 'on-push-do-doco' and 'Upload Python Package' GitHub Actions