### PR TITLE
Naming things

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# Need more hooks? see https://pre-commit.com/hooks.html
+
+repos:
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+        args: [--safe]
+        language_version: python3.6
+
+#  - repo: https://github.com/pre-commit/pre-commit-hooks
+#    rev: v2.3.0
+#    hooks:
+#      - id: check-merge-conflict
+#      - id: end-of-file-fixer
+#      - id: flake8
+#        additional_dependencies: ["flake8-bugbear == 19.3.0"]
+#        language_version: python3.8
+#      - id: trailing-whitespace
+
+#  - repo: https://github.com/asottile/pyupgrade
+#    rev: v1.12.0
+#    hooks:
+#      - id: pyupgrade
+#        args: [--py36-plus]

--- a/approvaltests/approvals.py
+++ b/approvaltests/approvals.py
@@ -14,18 +14,19 @@ from approvaltests.list_utils import format_list
 from approvaltests.reporters.diff_reporter import DiffReporter
 from approvaltests.string_writer import StringWriter
 
-DEFAULT_REPORTER = local()
+_DEFAULT_REPORTER = DiffReporter()
+_THREAD_LOCAL_STORE = local()
 
 
 def set_default_reporter(reporter):
-    global DEFAULT_REPORTER
-    DEFAULT_REPORTER.v = reporter
+    _THREAD_LOCAL_STORE.reporter = reporter
     
 
 def get_default_reporter():
-    if not hasattr(DEFAULT_REPORTER, "v") or DEFAULT_REPORTER.v is None:
-        return DiffReporter()
-    return DEFAULT_REPORTER.v
+    try:
+        return _THREAD_LOCAL_STORE.reporter or _DEFAULT_REPORTER
+    except AttributeError:
+        return _DEFAULT_REPORTER
 
 
 def get_reporter(reporter):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,16 @@
 [tox]
-envlist = py36,py37,py38
+envlist = lint,py36,py37,py38
 changedir = './tests/'
 
 [testenv]
 commands = python -m pytest
+
+[testenv:lint]
+description = run pre-commit and automatically install the hook
+deps = pre-commit
+skip_install = True
+commands =
+    ; https://pre-commit.com/
+    pre-commit run --all-files
+    ; automatically install hook at .git/hooks
+    {envdir}/bin/pre-commit install


### PR DESCRIPTION
I noticed this, when adjusting the pytest plugin. I was confused by `DEFAULT_REPORTER` as it is a lie. It is a threading local object that will hold the default reporter as an attribute when fetched, so this should make this clearer. 

The global keyword is also not needed, as the object is being updated and not replaced.