### PR TITLE
Fix: add empty-files install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     python_requires=">=3.6.1",
     packages=find_packages(exclude=["tests*"]),
     package_data={"approvaltests": ["reporters/reporters.json"]},
-    install_requires=["pyperclip==1.5.27", "pytest","bs4"],
+    install_requires=["pyperclip==1.5.27", "pytest", "bs4", "empty-files"],
     long_description=(HERE / "README.md").read_text(),
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
## Description

Add missing installation dependency `empty-files`.

## The solution

In version 3.0.0, a new dependency was added into `requirements.txt` and was used in `utils.py`. But it was not listed as installation dependency. This leads to runtime error.

We add this dependency to `setup.py` providing it being installed along with `approvaltests`.