### PR TITLE
Fix beautifulsoup4 dependency

### DIFF
--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -1,4 +1,4 @@
 pyperclip
 empty-files
-bs4
+beautifulsoup4
 pytest


### PR DESCRIPTION
bs4 is available on pypi to prevent namesquating. It's not meant to be consumed

https://pypi.org/project/bs4/