### PR TITLE
fix VSCode reporter on MacOS

### DIFF
--- a/approvaltests/reporters/diff_reporter.py
+++ b/approvaltests/reporters/diff_reporter.py
@@ -4,7 +4,7 @@ from approvaltests.reporters.generic_diff_reporter_factory import (
 from .python_native_reporter import PythonNativeReporter
 from .first_working_reporter import FirstWorkingReporter
 from .report_with_diff_command_line import ReportWithDiffCommandLine
-from .report_with_vscode import ReportWithVSCode
+from .report_with_vscode import ReportWithVSCode, ReportWithVSCodeMacOS
 
 
 class DiffReporter(FirstWorkingReporter):
@@ -23,6 +23,6 @@ class DiffReporter(FirstWorkingReporter):
 
         reporters = list(factory.get_all_reporters_from_config())
         reporters.extend(
-            [ReportWithVSCode(), ReportWithDiffCommandLine(), PythonNativeReporter()]
+            [ReportWithVSCode(), ReportWithVSCodeMacOS(), ReportWithDiffCommandLine(), PythonNativeReporter()]
         )
         super(__class__, self).__init__(*reporters)

--- a/approvaltests/reporters/report_with_vscode.py
+++ b/approvaltests/reporters/report_with_vscode.py
@@ -1,6 +1,10 @@
 from .generic_diff_reporter import GenericDiffReporter, create_config
 
 
+class ReportWithVSCodeMacOS(GenericDiffReporter):
+    def __init__(self):
+        super().__init__(config=create_config(["ReportWithVSCode", "/Applications/Visual Studio Code.app/contents/Resources/app/bin/code", ["-d"]]))
+
 class ReportWithVSCode(GenericDiffReporter):
     def __init__(self):
         super().__init__(config=create_config(["ReportWithVSCode", "code", ["-d"]]))

--- a/tests/reporters/approved_files/test_diff_reporter.test_default_reporter_chain.approved.txt
+++ b/tests/reporters/approved_files/test_diff_reporter.test_default_reporter_chain.approved.txt
@@ -39,6 +39,12 @@ FirstWorkingReporter({
     "path": "code"
 }, {
     "arguments": [
+        "-d"
+    ],
+    "name": "ReportWithVSCode",
+    "path": "/Applications/Visual Studio Code.app/contents/Resources/app/bin/code"
+}, {
+    "arguments": [
         "-u"
     ],
     "name": "ReportWithDiffCommandLine",


### PR DESCRIPTION
## Description

On MacOS, VS Code was not firing to show the diffs.

## The solution

Add a new Reporter with the absolute path.