### PR TITLE
Fix small typo in Options documentation header

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -1,23 +1,25 @@
 # Options
 
 <!-- toc -->
+
 ## Contents
 
-  * [Configuriation for verify](#configuriation-for-verify)
-  * [Inline Approvals](#inline-approvals)
-    * [Known Issues](#known-issues)<!-- endToc -->
+- [Configuriation for verify](#configuriation-for-verify)
+- [Inline Approvals](#inline-approvals)
+  - [Known Issues](#known-issues)<!-- endToc -->
 
-## Configuriation for verify
-All verify methods take an optional options parameter. This allows you to configure 
-* The reporter
-* Scrubbers
-* file extensions
+## Configuration for verify
 
+All verify methods take an optional options parameter. This allows you to configure
+
+- The reporter
+- Scrubbers
+- file extensions
 
 ## Inline Approvals
 
 ### Known Issues
 
-* Pycharm automatically removes trailing whitespace, which can cause the approval file to be different from the actual output.  
-  * To disable this behavior go to:
-  * File -> Settings -> Editor -> General -> On Save -> [ ] Remove trailing spaces
+- Pycharm automatically removes trailing whitespace, which can cause the approval file to be different from the actual output.
+  - To disable this behavior go to:
+  - File -> Settings -> Editor -> General -> On Save -> [ ] Remove trailing spaces


### PR DESCRIPTION
## Description

Fix a small typo in documentation Option Markdown header

## The solution

Documentation only, no source code modified. 

All other modification besides L11 are done by prettier Markdown formatter

