### PR TITLE
- F move verify_argument_parser scrubber to caller

### DIFF
--- a/approvaltests/approvals.py
+++ b/approvaltests/approvals.py
@@ -417,11 +417,7 @@ def verify_argument_parser(
     options: Optional[Options] = None,
 ) -> None:
     parser.formatter_class = lambda prog: argparse.HelpFormatter(prog, width=200)
-    options = options or Options()
-    scrubber = lambda t: t.replace("options:", "<optional header>:").replace(
-        "optional arguments:", "<optional header>:"
-    )
     verify(
         parser.format_help(),
-        options=options.with_scrubber(scrubber),
+        options=options,
     )

--- a/tests/test_find_stale_approved_files.py
+++ b/tests/test_find_stale_approved_files.py
@@ -52,7 +52,10 @@ def execute_script(directory, log_file):
 
 
 def test_create_argument_parser():
-    verify_argument_parser(create_argument_parser())
+    scrubber = lambda t: t.replace("options:", "<optional header>:").replace(
+        "optional arguments:", "<optional header>:"
+    )
+    verify_argument_parser(create_argument_parser(), options=Options().with_scrubber(scrubber))
 
 
 def test_find_stale_approved_files():

--- a/tests/test_verify_argument_parser.py
+++ b/tests/test_verify_argument_parser.py
@@ -1,9 +1,6 @@
 import argparse
-import os
 
-from approvaltests import verify_argument_parser
-from tests.find_stale_approved_files import create_argument_parser
-from approvaltests.core.options import Options
+from approvaltests import verify_argument_parser, Options
 
 
 def test_argument_parser():

--- a/tests/test_verify_argument_parser.py
+++ b/tests/test_verify_argument_parser.py
@@ -3,6 +3,7 @@ import os
 
 from approvaltests import verify_argument_parser
 from tests.find_stale_approved_files import create_argument_parser
+from approvaltests.core.options import Options
 
 
 def test_argument_parser():
@@ -13,4 +14,8 @@ def test_argument_parser():
     parser.add_argument("1st_argument", help="1st argument help text")
     parser.add_argument("--optional_argument", help="An Optional Argument help text")
     parser.add_argument("long_argument", help=f"{'Very' * 100} Long message")
-    verify_argument_parser(parser)
+
+    scrubber = lambda t: t.replace("options:", "<optional header>:").replace(
+        "optional arguments:", "<optional header>:"
+    )
+    verify_argument_parser(parser, options=Options().with_scrubber(scrubber))


### PR DESCRIPTION
Not every user of `verify_argument_parser` wants to scrub the `options` header, or if they want to scrub it they may want to scrub it differently (e.g. `[OPTIONS HEADER]`), or they may want to scrub based on the version of Python (`if sys.version_info >= (3, 10)...`).