### PR TITLE
. e Run tests cleanup

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,8 @@
 numpy
 pylint
-pytest-asyncio==0.21.1 # 0.23 has a bug 2023/12/3
 
+pytest
+pytest-asyncio==0.21.1 # 0.23 has a bug 2023/12/3
 pytest-xdist
+
 # mariadb

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,5 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
 python3 -m pip --disable-pip-version-check install tox
 tox -e py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,3 @@
 python -m pip install --upgrade pip
 pip install tox
-pip install pytest 
 tox -e py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,2 @@
-python -m pip install --upgrade pip
-pip install tox
+pip --disable-pip-version-check install tox
 tox -e py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,2 @@
-pip --disable-pip-version-check install tox
+python3 -m pip --disable-pip-version-check install tox
 tox -e py


### PR DESCRIPTION
`run_tests.sh` had some problems:

- it used `python ...` to upgrade Pip, but `python` isn't guaranteed to be available. On my machine, it's `python3` and I believe that is more common.
- when any command failed, the script would keep running. This made it hard for people to notice that we were failing to upgrade Pip
- There's no need to upgrade Pip.
- Since we're already using Tox to manage virtual environments, we should let it manage pytest

## Summary by Sourcery

Improve the run_tests.sh script by switching to python3 for pip commands, removing the pip upgrade step, and leveraging Tox for managing pytest.

Build:
- Modify run_tests.sh to use python3 for pip installation and remove unnecessary pip upgrade.

Tests:
- Update run_tests.sh to utilize Tox for managing pytest instead of manual installation.