### PR TITLE
. t Add Python 3.12 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,3 +1,4 @@
+setuptools
 numpy
 pylint
 pytest-asyncio==0.21.1 # 0.23 has a bug 2023/12/3


### PR DESCRIPTION
Fixes #187

## Summary by Sourcery

CI:
- Add Python 3.12 to the testing matrix in the GitHub Actions workflow.