### PR TITLE
. e remove confusing `dev` tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,3 @@
-# run with: tox -e dev
 [tox]
 envlist = tests
 
@@ -10,10 +9,6 @@ deps = -rrequirements.txt
 commands = python -m pytest {posargs}
 deps = -rrequirements.prod.min.txt
     -rrequirements.test.txt
-
-[testenv:dev]
-usedevelop = True
-commands =
 
 [testenv:lint]
 description = run pre-commit and automatically install the hook


### PR DESCRIPTION
It doesn't appear to do anything.

## Summary by Sourcery

Chores:
- Remove the unused 'dev' tox environment from the tox configuration file.