### PR TITLE
. e don't pass environment to tox

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 python3 -m pip --disable-pip-version-check install tox
-tox -e py
+tox


### PR DESCRIPTION
`tox` (with no arguments), appears to do the right thing. Specifically:
- `tox -e py` appears to run `testenv`
- just `tox` runs everything in `envlist` which is `tests`, which magically resolves to `testenv`

The latter seems better, as it lets us make use of `envlist`.

Here's a screenshot from the GitHub actions showing that tests are still being run with this change:

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/23f2efb0-03c5-4c04-90ff-a9db10387c5a">


## Summary by Sourcery

Enhancements:
- Remove unnecessary environment variable passing to tox in the test script.