### PR TITLE
- r run mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,166 @@ warn_unused_configs = True
 exclude =
     venv/
     .tox/
+
+[mypy-approval_utilities.utilities.clipboard_utilities]
+disable_error_code =
+    import-untyped,
+
+[mypy-approval_utilities.approvaltests.core.verify_parameters]
+disable_error_code =
+    name-defined,
+
+[mypy-approvaltests.pairwise_combinations]
+disable_error_code =
+    import-untyped,
+
+[mypy-approvaltests.inline.split_code]
+disable_error_code =
+    union-attr,
+
+[mypy-approval_utilities.approvaltests.core.verifiable]
+disable_error_code =
+    name-defined,
+
+[mypy-approval_utilities.utilities.markdown_table]
+disable_error_code =
+    name-defined,
+    no-any-return,
+
+[mypy-approvaltests.namer.namer_base]
+disable_error_code =
+    assignment,
+    return-value,
+
+[mypy-approval_utilities.utils]
+disable_error_code =
+    assignment,
+    import-untyped,
+
+[mypy-approval_utilities.utilities.logger.logging_instance]
+disable_error_code =
+    annotation-unchecked,
+    arg-type,
+    arg-type,
+    assignment,
+    no-any-return,
+    valid-type,
+
+[mypy-approvaltests.binary_writer]
+disable_error_code =
+    arg-type,
+    assignment,
+
+[mypy-approvaltests.reporters.generic_diff_reporter]
+disable_error_code =
+    return-value,
+
+[mypy-approvaltests.reporters.clipboard_reporter]
+disable_error_code =
+    assignment,
+
+[mypy-approvaltests.reporters.default_reporter_factory]
+disable_error_code =
+    no-any-return,
+
+[mypy-approvaltests.namer.stack_frame_namer]
+disable_error_code =
+    assignment,
+
+[mypy-approval_utilities.utilities.logger.simple_logger]
+disable_error_code =
+    assignment,
+    no-any-return,
+    valid-type,
+
+[mypy-approvaltests.scrubbers.scrubbers]
+disable_error_code =
+    arg-type,
+    name-defined,
+
+[mypy-approvaltests.reporters.generic_diff_reporter_factory]
+disable_error_code =
+    abstract,
+
+[mypy-approvaltests.file_approver]
+disable_error_code =
+    no-any-return,
+    var-annotated,
+
+[mypy-approvaltests.reporters.executable_command_reporter]
+disable_error_code =
+    arg-type,
+
+[mypy-approvaltests.inline.inline_options]
+disable_error_code =
+    name-defined,
+
+[mypy-approvaltests.core.options]
+disable_error_code =
+    assignment,
+    no-any-return,
+
+[mypy-approvaltests.approvals]
+disable_error_code =
+    arg-type,
+    assignment,
+    attr-defined,
+    import-untyped,
+    no-any-return,
+    return-value,
+    union-attr,
+
+[mypy-approvaltests.combination_approvals]
+disable_error_code =
+    arg-type,
+    assignment,
+
+[mypy-approvaltests.asserts]
+disable_error_code =
+    assignment,
+
+[mypy-approvaltests.namer.inline_python_reporter]
+disable_error_code =
+    annotation-unchecked,
+    assignment,
+    truthy-function,
+
+[mypy-approvaltests.namer.inline_comparator]
+disable_error_code =
+    annotation-unchecked,
+    assignment,
+    name-defined,
+    no-any-return,
+
+[mypy-approvaltests.utilities.command_line_approvals]
+disable_error_code =
+    assignment,
+    valid-type,
+
+[mypy-approvaltests.utilities.logging.logging_approvals]
+disable_error_code =
+    import-untyped,
+
+[mypy-approvaltests.reporters.report_to_diff_engine]
+disable_error_code =
+    return,
+
+[mypy-approvaltests.namer.default_namer_factory]
+disable_error_code =
+    arg-type,
+    assignment,
+
+[mypy-approvaltests.integrations.mrjob.mrjob_approvals]
+disable_error_code =
+    arg-type,
+    import-untyped,
+
+[mypy-approvaltests.inline.parse]
+disable_error_code =
+    arg-type,
+    no-any-return,
+
+[mypy-approvaltests.integrations.pytest.py_test_namer]
+disable_error_code =
+    assignment,
+    attr-defined,

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,4 +3,6 @@
 [mypy]
 warn_return_any = True
 warn_unused_configs = True
-exclude = venv/
+exclude =
+    venv/
+    .tox/

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,7 @@
 setuptools
 numpy
 pylint
+mypy
 
 pytest
 pytest-asyncio==0.21.1 # 0.23 has a bug 2023/12/3

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 python3 -m pip --disable-pip-version-check install tox
-tox -e py
+tox -e py && tox -e type

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,16 @@
 # run with: tox -e dev
 [tox]
-envlist = tests
+envlist =
+    tests
+    type
 
 [testenv]
 commands = python -m pytest {posargs}
 deps = -rrequirements.txt
+
+[testenv:type]
+commands = mypy approvaltests approval_utilities
+deps = -rrequirements.test.txt
 
 [testenv:min]
 commands = python -m pytest {posargs}


### PR DESCRIPTION
Add mypy to run_tests + suppress all existing mypy violations.

## Summary by Sourcery

Integrate mypy type checking into the project by adding it to the tox configuration and the CI workflow, while suppressing existing mypy violations.

Enhancements:
- Integrate mypy type checking into the testing process by adding a new 'type' environment in tox.

CI:
- Add mypy type checking to the CI workflow by including it in the 'run_tests.sh' script.