### PR TITLE
. e use `python -m` for consistency

### DIFF
--- a/.github/workflows/formatting_and_snippets.yml
+++ b/.github/workflows/formatting_and_snippets.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Run black
       run: |
-        pip install black
+        python -m pip install black
         python -m black .
     - name: Run MarkdownSnippets
       run: |


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Use `python -m` to invoke pip and black for consistency.