### PR TITLE
. t temporarily disable test that fails in Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         os:
           - macos-latest
           - ubuntu-latest

--- a/tests/test_inline_approvals.py
+++ b/tests/test_inline_approvals.py
@@ -1,6 +1,7 @@
 import unittest
 from inspect import FrameInfo
 from typing import Callable, Any
+import sys
 
 import pytest
 
@@ -149,6 +150,7 @@ def get_preceding_whitespace():
 
 
 # fmt: off
+@unittest.skipIf(sys.version_info >= (3, 13), "__doc__ removes preceding whitespace in Python 3.13+")
 def test_preceding_whitespace():
     """
         4 whitespaces


### PR DESCRIPTION
## Summary by Sourcery

Temporarily disable a test that fails in Python 3.13 due to a language change in docstring whitespace handling

CI:
- Add Python 3.13 to the test matrix

Tests:
- Skip a specific test for Python 3.13 due to a change in __doc__ attribute behavior