### PR TITLE
Document APPROVALTESTS_CONFIG for viewing test diffs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# ApprovalTests.Python - Claude Development Notes
+
+## Running Tests & Type Checking
+
+- Use `uv run tox -e mypy` to run mypy type checking
+- Use `uv run tox -e py` to run unit tests
+- Use `./build_and_test.sh` for full build (but it's slow)
+
+## MyPy Configuration
+
+- Currently enabling strict mode rules incrementally
+- Enabled: `disallow_any_generics` (completed)
+- Still disabled: `no_implicit_reexport`, `disallow_subclassing_any`
+- See `mypy.ini` for current configuration
+
+## Code Style
+
+- Use `uv tool run ruff check .` for linting
+- Use `uv tool run black .` for formatting
+- Follow existing patterns in the codebase
+- Prefer complete function names and type hints over docstrings
+
+## Approval Tests
+
+- Use `APPROVALTESTS_CONFIG='{"reporter":"PythonNativeReporter"}' uv run python -m pytest tests/path/to/test.py -v -s` to see approval test diffs directly in the terminal


### PR DESCRIPTION
## Summary
• Documented the `APPROVALTESTS_CONFIG` environment variable for viewing approval test diffs directly in terminal
• Added to CLAUDE.md for future reference during development

## Useful Command
```bash
APPROVALTESTS_CONFIG='{"reporter":"PythonNativeReporter"}' uv run python -m pytest tests/path/to/test.py -v -s
```

## Benefits
• See approval test diffs directly in terminal output
• No need to manually check received files  
• Faster development workflow for approval tests
• Uses PythonNativeReporter instead of external diff tools

This was discovered while working on the DateScrubber improvements and proved very useful for debugging approval test failures.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add a new CLAUDE.md file with developer notes covering test & type-checking commands, code style guidelines, MyPy configuration, and instructions for using the APPROVALTESTS_CONFIG environment variable to view approval test diffs directly in the terminal.

Documentation:
- Introduce CLAUDE.md with development setup and workflow instructions.
- Document the APPROVALTESTS_CONFIG environment variable for in-terminal approval test diffs.