### PR TITLE
Add ReportWithOpeningFile reporter for issue #205

### DIFF
--- a/approvaltests/reporters/__init__.py
+++ b/approvaltests/reporters/__init__.py
@@ -12,4 +12,5 @@ from .python_native_reporter import *
 from .received_file_launcher_reporter import *
 from .report_all_to_clipboard import *
 from .report_by_creating_diff_file import *
+from .report_with_opening_file import *
 from .reporter_that_automatically_approves import *

--- a/approvaltests/reporters/report_with_opening_file.py
+++ b/approvaltests/reporters/report_with_opening_file.py
@@ -1,0 +1,38 @@
+import platform
+from subprocess import call
+from typing import List
+
+from typing_extensions import override
+
+from approvaltests.core.reporter import Reporter
+
+
+class ReportWithOpeningFile(Reporter):
+    """
+    A reporter that opens the received file using the
+    system default file viewer.
+
+    Uses platform-specific commands:
+    - macOS: open
+    - Windows: start
+    - Linux/Unix: xdg-open
+
+    Depending on the file viewer being launched,
+    the test suite execution may halt until the
+    user has closed the new process.
+    """
+
+    @staticmethod
+    def get_command(received_path: str) -> List[str]:
+        system = platform.system()
+        if system == "Darwin":
+            return ["open", received_path]
+        if system == "Windows":
+            return ["start", received_path]
+        return ["xdg-open", received_path]
+
+    @override
+    def report(self, received_path: str, approved_path: str) -> bool:
+        command_array = self.get_command(received_path)
+        call(command_array)
+        return True

--- a/tests/reporters/test_report_with_opening_file.py
+++ b/tests/reporters/test_report_with_opening_file.py
@@ -27,7 +27,7 @@ def test_get_command_unknown_system() -> None:
         assert command == ["xdg-open", "test.txt"]
 
 
-@patch("subprocess.call")
+@patch("approvaltests.reporters.report_with_opening_file.call")
 def test_report_calls_command(mock_call: MagicMock) -> None:
     reporter = ReportWithOpeningFile()
     with patch("platform.system", return_value="Darwin"):

--- a/tests/reporters/test_report_with_opening_file.py
+++ b/tests/reporters/test_report_with_opening_file.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, patch
+
+from approvaltests.reporters.report_with_opening_file import ReportWithOpeningFile
+
+
+def test_get_command_darwin() -> None:
+    with patch("platform.system", return_value="Darwin"):
+        command = ReportWithOpeningFile.get_command("test.txt")
+        assert command == ["open", "test.txt"]
+
+
+def test_get_command_windows() -> None:
+    with patch("platform.system", return_value="Windows"):
+        command = ReportWithOpeningFile.get_command("test.txt")
+        assert command == ["start", "test.txt"]
+
+
+def test_get_command_linux() -> None:
+    with patch("platform.system", return_value="Linux"):
+        command = ReportWithOpeningFile.get_command("test.txt")
+        assert command == ["xdg-open", "test.txt"]
+
+
+def test_get_command_unknown_system() -> None:
+    with patch("platform.system", return_value="UnknownOS"):
+        command = ReportWithOpeningFile.get_command("test.txt")
+        assert command == ["xdg-open", "test.txt"]
+
+
+@patch("subprocess.call")
+def test_report_calls_command(mock_call: MagicMock) -> None:
+    reporter = ReportWithOpeningFile()
+    with patch("platform.system", return_value="Darwin"):
+        result = reporter.report("received.txt", "approved.txt")
+        mock_call.assert_called_once_with(["open", "received.txt"])
+        assert result is True


### PR DESCRIPTION
## Summary
• Implements `ReportWithOpeningFile` reporter that opens received files using system default viewer
• Provides cross-platform support for macOS (open), Windows (start), and Linux/Unix (xdg-open)

## Test plan
- [x] Unit tests cover all platform scenarios with mocking
- [x] Tests verify correct command generation for each OS
- [x] Tests confirm subprocess.call is invoked with proper arguments
- [x] Code formatted with black and follows existing patterns
- [x] All tests pass via tox

🤖 Generated with [Claude Code](https://claude.ai/code)