### PR TITLE
. e run CI on ubuntu-slim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - "3.14"
         os:
           - macos-latest
-          - ubuntu-latest
+          - ubuntu-slim
           - windows-latest
 
     steps:


### PR DESCRIPTION
To help catch implicit dependencies in the build.

Read about `ubuntu-slim` here: https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md

## Summary by Sourcery

CI:
- Update the CI test matrix to use ubuntu-slim in place of ubuntu-latest for Linux runs.