### PR TITLE
. d use absolute paths

### DIFF
--- a/docs/how_to/verify-binary.md
+++ b/docs/how_to/verify-binary.md
@@ -29,7 +29,7 @@ with open(filename, mode="rb") as f:
 
 Which will produce
 
-![Approved image](../../tests/approved_files/VerifyTests.test_verify_file_binary_file.approved.png)
+![Approved image](/tests/approved_files/VerifyTests.test_verify_file_binary_file.approved.png)
 
 ### Approving NumPy arrays
 This more detailed example demonstrates how you could use `verify_binary` to approve NumPy arrays. 

--- a/docs/tutorial/intro-to-reporters.md
+++ b/docs/tutorial/intro-to-reporters.md
@@ -18,11 +18,11 @@ The default reporter will search your machine for any installed diff tool.
 
 ## Supported Diff Tools  
 
-See [diff_reporters.csv](../../diff_reporters.csv) for a list of supported diff tools.
+See [diff_reporters.csv](/diff_reporters.csv) for a list of supported diff tools.
 
 ## Customizing the reporters.json
 
-You can add a diff tool and path to ApprovalTests by editing the [`reporters.json`](../../approvaltests/reporters/reporters.json) file.
+You can add a diff tool and path to ApprovalTests by editing the [`reporters.json`](/approvaltests/reporters/reporters.json) file.
 
 ## resources
 1. [configuring a reporter](../configuration.md#how-to-configure-a-default-reporter-for-your-system)

--- a/mob-sessions-retros/2023-09-17 error_on_multiple_verify_calls_for_single_approved_file.md
+++ b/mob-sessions-retros/2023-09-17 error_on_multiple_verify_calls_for_single_approved_file.md
@@ -1,6 +1,6 @@
 # Background
 
-Using the same approved file more than once can be useful, but it is rarely the case. See [](../docs/how_to/verify_both_logs_and_results.md)
+Using the same approved file more than once can be useful, but it is rarely the case. See [verify_both_logs_and_results.md](/docs/how_to/verify_both_logs_and_results.md)
 
 # Current Behaviour
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Change internal documentation links from relative to absolute paths for diff tools, configuration files, images, and related how-to guides.