### PR TITLE
Test upcoming Mac runner upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - "3.13"
           - "3.14"
         os:
-          - macos-latest
+          - macos-26
           - ubuntu-slim
           - windows-latest
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Change GitHub Actions test matrix to run on the macos-26 runner instead of macos-latest.