### PR TITLE
verify_argument_parser with value

### DIFF
--- a/tests/approved_files/test_verify_argument_parser.test_argument_parser.approved.txt
+++ b/tests/approved_files/test_verify_argument_parser.test_argument_parser.approved.txt
@@ -1,4 +1,4 @@
-usage: my_program.py [-h] [--optional_argument OPTIONAL_ARGUMENT] 1st_argument long_argument
+usage: my_program.py [-h] [--optional_argument OPTIONAL_ARGUMENT] [-c COUNT] 1st_argument long_argument
 
 My Description
 
@@ -12,3 +12,5 @@ positional arguments:
   -h, --help            show this help message and exit
   --optional_argument OPTIONAL_ARGUMENT
                         An Optional Argument help text
+  -c COUNT, --count COUNT
+                        Number of items to process

--- a/tests/test_verify_argument_parser.py
+++ b/tests/test_verify_argument_parser.py
@@ -11,6 +11,7 @@ def test_argument_parser() -> None:
     )
     parser.add_argument("1st_argument", help="1st argument help text")
     parser.add_argument("--optional_argument", help="An Optional Argument help text")
+    parser.add_argument("-c", "--count", type=int, help="Number of items to process")
     parser.add_argument("long_argument", help=f"{'Very' * 100} Long message")
     verify_argument_parser(parser)
 


### PR DESCRIPTION
This behavior changed in newer Python. See https://github.com/python/cpython/issues/101599

Should we:

- make one test for older Python; one for newer Python
- add a scrubber
- discard this test change, accepting that this detail isn't tested

?

Also consider removing the `skipIf()` from `test_command_line_callouts.test_argument_parse`.